### PR TITLE
add years range feature (resolve #12)

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -17,10 +17,13 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         persianDatePickerView.style = .short
+        //persianDatePickerView.setMaxYear(toYear : 1400)
+        persianDatePickerView.setYearsRange(fromYear : 1390 , toYear : 1400)
         persianDatePickerView.onChange = {(year, month, day) in
             print("\(year)/\(month)/\(day)")
 //            print("gregorian Date : \(self.persianDatePickerView.getGregorianDate()!)")
             print("persian Date : \(self.persianDatePickerView.getPersianDate())")
+            print(" date = > \(self.persianDatePickerView.getGregorianDate())")
         }
         
     }
@@ -41,6 +44,7 @@ class ViewController: UIViewController {
         pView.show(in: self) { persianDate in
             print(persianDate)
         }
+        
     }
     
 }

--- a/PersianDatePicker/PersianDatePickerView.swift
+++ b/PersianDatePicker/PersianDatePickerView.swift
@@ -19,7 +19,7 @@ public class PersianDatePickerView: UIView {
 	public var day = 1
 
 	fileprivate let pickerView = UIPickerView()
-	fileprivate let persianDateDataSource = PersianDateDataSource()
+    fileprivate var persianDateDataSource = PersianDateDataSource()
 	
 	public var onChange: (Listener)?
 	public var font: UIFont?
@@ -65,7 +65,17 @@ public class PersianDatePickerView: UIView {
 		pickerView.delegate = self
 	}
 	
-    
+    public func setYearsRange(fromYear : Int , toYear : Int) {
+        persianDateDataSource.years = Array (fromYear...toYear)
+    }
+    public func setMaxYear(toYear : Int) {
+        persianDateDataSource.years = Array (1300...toYear)
+    }
+    public func setMinYear(fromYear : Int) {
+        persianDateDataSource.years = Array (fromYear...1500)
+    }
+
+
     public func gotoCurrentDate() {	
         let currentDate = persianDateDataSource.todayCompononents()
         setDatePicker(year: currentDate.year, month: currentDate.month, day: currentDate.day)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ persianDatePicker.onChange = { (year, month, day) in
     self.txtDate.text = "\(year)/\(month)/\(day)"
 }
 ```
+if you want to set years range:
+
+```swift
+persianDatePickerView.setYearsRange(fromYear : 1390 , toYear : 1400)
+```
 
 if you want to have persian date:
 


### PR DESCRIPTION
I want to filter  years in a range. for example to list orders from 1380 to 1390. This pull request helps to select a range in years.